### PR TITLE
add onclick handler support

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -17,13 +17,18 @@ fn App() -> Element {
         document::Style { href: CSS }
         Map {
             initial_position: MapPosition::new(51.505, -0.09, 5.0),
-            for i in 0..markers.len() {
+            on_click: move |pos: LatLng| {
+                if let Some(marker) = markers.write().last_mut() {
+                    marker.2 = pos;
+                }
+            },
+            for marker in markers() {
                 Marker {
-                    coordinate: markers.map(move |v| &v[i].2),
+                    coordinate: marker.2,
                     Popup {
-                        b { "{&markers.get(i).unwrap().0}" }
+                        b { "{marker.0}"}
                         br {}
-                        "{&markers.get(i).unwrap().1}"
+                        "{marker.1}"
                     }
                 }
             }
@@ -54,13 +59,11 @@ fn App() -> Element {
             onclick: move |_| {
                 if let Some(last) = markers().last() {
                     let new_lat_lng = last.2 + LatLng::new(0.5, 0.5);
-                    let mut new_markers = markers().to_vec();
-                    new_markers.push((
+                    markers.write().push((
                         "New City",
                         "A new location",
                         new_lat_lng
                     ));
-                    markers.set(new_markers);
                 }
             },
             "Add Marker"

--- a/dioxus-leaflet/assets/dioxus_leaflet.js
+++ b/dioxus-leaflet/assets/dioxus_leaflet.js
@@ -18,6 +18,15 @@ window.DioxusLeaflet = class DioxusLeaflet {
         }
     }
 
+    static async registerOnClickHandlerMapAsync(recv, send) {
+        let {map_id} = await recv();
+        const map = this._maps.get(map_id);
+        map.on('click', (e) => {
+            send(e.latlng);
+        })
+
+    }
+
     static updateMap({ map_id, initial_position, options }) {
         // Initialize the map with options
         const map = this._maps.get(map_id) ?? L.map(`dioxus-leaflet-${map_id}`, {
@@ -128,6 +137,7 @@ window.DioxusLeaflet = class DioxusLeaflet {
         this._popups.set(marker_id, { body, options });
 
         let marker = this._objects.get(marker_id);
+        console.log(this._objects);
         if (marker) {
             marker.unbindPopup();
             marker.bindPopup(body, options);

--- a/dioxus-leaflet/src/components/map.rs
+++ b/dioxus-leaflet/src/components/map.rs
@@ -1,5 +1,5 @@
 use dioxus::prelude::*;
-use crate::{interop, MapOptions, MapPosition};
+use crate::{interop, LatLng, MapOptions, MapPosition};
 
 const MAP_CSS: Asset = asset!("/assets/dioxus_leaflet.scss");
 
@@ -33,7 +33,7 @@ pub fn Map(
     style: Option<String>,
     
     /// Callback when map is clicked
-    on_click: Option<EventHandler<MapPosition>>,
+    on_click: Option<EventHandler<LatLng>>,
     
     /// Callback when map is moved
     on_move: Option<EventHandler<MapPosition>>,
@@ -52,6 +52,9 @@ pub fn Map(
         let opts = options.clone();
         spawn(async move {
             if let Err(e) = interop::update_map(id, &pos, &opts).await {
+                load_error.set(Some(e));
+            }
+            if let Err(e) = interop::register_onclick_handler_map(id, on_click).await {
                 load_error.set(Some(e));
             }
         });


### PR DESCRIPTION
I've added a way to register and handle the onclick events on a map, as per #9 
I've added an example in the demo application, where now clicking on the map moves the last marker.

Notes:
- I've noticed that after moving the marker, the next marker created using the button has a blank popup. But the moved marker keeps his popup attached. So I have no clue why the next created marker suddenly has issues.
- I've changed the signature from EventHandler<MapPosition> to EventHandler<LatLng> as it better corresponds with the output of the event handler from leaflet. 